### PR TITLE
Fix hover issue when leaving the subreddit.

### DIFF
--- a/css/minified/r-clearshift.css
+++ b/css/minified/r-clearshift.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/minified/r-greatxboxdeals.css
+++ b/css/minified/r-greatxboxdeals.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/minified/r-microsoftteams.css
+++ b/css/minified/r-microsoftteams.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/minified/r-windows.css
+++ b/css/minified/r-windows.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/minified/r-windows10.css
+++ b/css/minified/r-windows10.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/minified/r-windows8.css
+++ b/css/minified/r-windows8.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/minified/r-windowsapps.css
+++ b/css/minified/r-windowsapps.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/minified/r-windowsmobile.css
+++ b/css/minified/r-windowsmobile.css
@@ -78,7 +78,7 @@ Secondary: #7A0218
 #header-img {
   text-indent: -9999px;
   display: inline-block;
-  margin-top: 110px;
+  margin-top: 111px;
   position: absolute;
   z-index: 99;
   height: 27px;

--- a/css/r-clearshift.css
+++ b/css/r-clearshift.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/css/r-greatxboxdeals.css
+++ b/css/r-greatxboxdeals.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/css/r-microsoftteams.css
+++ b/css/r-microsoftteams.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/css/r-windows.css
+++ b/css/r-windows.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/css/r-windows10.css
+++ b/css/r-windows10.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/css/r-windows8.css
+++ b/css/r-windows8.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/css/r-windowsapps.css
+++ b/css/r-windowsapps.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/css/r-windowsmobile.css
+++ b/css/r-windowsmobile.css
@@ -62,7 +62,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-clearshift.css
+++ b/dist/css/r-clearshift.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-greatxboxdeals.css
+++ b/dist/css/r-greatxboxdeals.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-microsoftband.css
+++ b/dist/css/r-microsoftband.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-microsoftteams.css
+++ b/dist/css/r-microsoftteams.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-windows.css
+++ b/dist/css/r-windows.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-windows10.css
+++ b/dist/css/r-windows10.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-windows8.css
+++ b/dist/css/r-windows8.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-windowsapps.css
+++ b/dist/css/r-windowsapps.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/dist/css/r-windowsmobile.css
+++ b/dist/css/r-windowsmobile.css
@@ -77,7 +77,7 @@ Secondary: #7A0218
   #header-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;

--- a/scss/core/_core.scss
+++ b/scss/core/_core.scss
@@ -92,7 +92,7 @@ Secondary: #7A0218
   &-img {
     text-indent: -9999px;
     display: inline-block;
-    margin-top: 110px;
+    margin-top: 111px;
     position: absolute;
     z-index: 99;
     height: 27px;


### PR DESCRIPTION
When hovering over leaving Reddit, the icon and background are above all of the other elements on the `tabmenu` div by one pixel. This PR fixes that by lowering the icon by one pixel.